### PR TITLE
Add documentation strings to functions

### DIFF
--- a/src/functions/configure.ts
+++ b/src/functions/configure.ts
@@ -1,5 +1,8 @@
 import { ToolKitModule } from "../module/index";
 
-export async function configureTips() {
+/**
+ * Registers new tips for the session
+ */
+export async function configureTips(): Promise<void> {
   return await ToolKitModule.configureTips();
 }

--- a/src/functions/resetTips.ts
+++ b/src/functions/resetTips.ts
@@ -1,5 +1,8 @@
 import { ToolKitModule } from "../module/index";
 
-export async function resetTips() {
+/**
+ * Clears any previously shown tips
+ */
+export async function resetTips(): Promise<void> {
   return await ToolKitModule.resetTips();
 }


### PR DESCRIPTION
Without reading the README.md I did not directly understand what these functions did. So I just added docstrings to make it more clear. 

And since they don't return anything I changed the return type to `Promise<void>`. TypeScript devs will say that is better I guess :)